### PR TITLE
Single-value relative risks are now digested

### DIFF
--- a/r_package/bestcost/R/compile_input.R
+++ b/r_package/bestcost/R/compile_input.R
@@ -80,8 +80,8 @@ compile_input <-
           # Check which risk of the vector is higher for an exp=10
           # (random value, it could be another one)
           erf_10 = c(bestcost::get_risk(exp = 10, erf_c = erf_c[1], erf_full = TRUE),
-                      bestcost::get_risk(exp = 10, erf_c = erf_c[2], erf_full = TRUE),
-                      bestcost::get_risk(exp = 10, erf_c = erf_c[3], erf_full = TRUE)),
+                     bestcost::get_risk(exp = 10, erf_c = erf_c[2], erf_full = TRUE),
+                     bestcost::get_risk(exp = 10, erf_c = erf_c[3], erf_full = TRUE)),
           rr = erf_10)
 
     }
@@ -91,9 +91,11 @@ compile_input <-
       erf_data %>%
       mutate(
         # Assign central estimate as well as lower and upper bound of rr values
-        erf_ci = ifelse(rr %in% min(rr), "lower",
-                       ifelse(rr %in% max(rr), "upper",
-                              "central"))) %>%
+        erf_ci = ifelse((rr>min(rr) & rr<max(rr)) |
+                          (min(rr)%in%max(rr)), "central",
+                        ifelse(rr %in% min(rr), "lower",
+                               ifelse(rr %in% max(rr), "upper",
+                               NA)))) %>%
 
       # In case of same value in mean and low and/or high, assign value randomly
       {if(sum(duplicated(.$rr))==1) dplyr::mutate(.,

--- a/r_package/bestcost/R/get_deaths.R
+++ b/r_package/bestcost/R/get_deaths.R
@@ -29,8 +29,8 @@ get_deaths <-
     # Add description of what happens in next code chunk ####
     deaths_by_list <- list()
 
-    for (s in c("female", "male")){
-      for (v in c("central", "lower", "upper")){
+    for(s in names(pop_impact[["pop_impact"]])){ # c(male, female)
+      for (v in unique(unlist(purrr::map(pop_impact[["pop_impact"]], names)))){ # c(central, lower, upper) or only central
         population_secondYear_lifetable <-
           paste0("population_", year_of_analysis+1)
 

--- a/r_package/bestcost/R/get_pop_impact.R
+++ b/r_package/bestcost/R/get_pop_impact.R
@@ -32,8 +32,8 @@ get_pop_impact <-
     # Get popOvertime
     popOverTime <- list()
 
-    for(s in c("female", "male")){
-      for(v in c("central", "lower", "upper")){
+    for(s in names(lifetab_withPop)){
+      for(v in paf$erf_ci){
         popOverTime[[s]][[v]] <-
           bestcost::project_pop(
             lifetab_withPop = lifetab_withPop[[s]],
@@ -50,8 +50,8 @@ get_pop_impact <-
 
     pop_impact <- list()
 
-    for(s in c("female", "male")){
-      for(v in c("central", "lower", "upper")){
+    for(s in names(lifetab_withPop)){
+      for(v in paf$erf_ci){
         pop_impact[[s]][[v]] <-
 
           bestcost::move_rows_up(popOTime = popOverTime[[s]][[v]],

--- a/r_package/bestcost/R/get_yld.R
+++ b/r_package/bestcost/R/get_yld.R
@@ -44,8 +44,8 @@ get_yld <-
     discount_factor <- corrected_discount_rate + 1
 
     # Calculate YLD ####
-    for(s in c("female", "male")){
-      for (v in c("central", "lower", "upper")){
+    for(s in names(pop_impact[["pop_impact"]])){ # c(male, female)
+      for (v in unique(unlist(purrr::map(pop_impact[["pop_impact"]], names)))){ # c(central, lower, upper) or only central
 
         ## Sum life years by year (result is data frame with 2 columns "year" & "impact" [which contains YLD]) ####
         lifeyears_byYear[[s]][[v]] <-

--- a/r_package/bestcost/R/get_yll.R
+++ b/r_package/bestcost/R/get_yll.R
@@ -5,8 +5,8 @@
 #' Get years of life lost
 #' @param pop_impact \code{Data frame} with projected population impact over time
 #' @param year_of_analysis \code{Numeric value} of the year of analysis, which corresponds to the first year of the life table,
-#' @param age_min \code{Numeric value}  with the minimal age to be considered for adults (by default 30, i.e. 30+),
-#' @param age_max \code{Numeric value}  with the maximal age to be considered for infants/children (by default 0, i.e. below 1 years old)
+#' @param age_min \code{Numeric value} with the minimal age to be considered for adults (by default 30, i.e. 30+),
+#' @param age_max \code{Numeric value} with the maximal age to be considered for infants/children (by default 0, i.e. below 1 years old)
 #' @param meta \code{Data frame} with meta-information such as input data, additional information and intermediate results.
 #' @param corrected_discount_rate \code{Numeric value}  with the annual discount rate as proportion (i.e. 0.1 instead of 10\%). It can be calculated as (1+discount_rate_beforeCorrection/1+rate_of_increase)-1
 #' @return
@@ -42,8 +42,8 @@ get_yll <-
     discount_factor <- corrected_discount_rate + 1
 
     # Calculate YLL ####
-    for(s in c("female", "male")){
-      for (v in c("central", "lower", "upper")){
+    for(s in names(pop_impact[["pop_impact"]])){ # c(male, female)
+      for (v in unique(unlist(purrr::map(pop_impact[["pop_impact"]], names)))){ # c(central, lower, upper) or only central
 
         ## Sum life years by year (result is data frame with 2 columns "year" & "impact" [which contains YLL]) ####
         lifeyears_byYear[[s]][[v]] <-

--- a/r_package/testing/testing_Rpackage.Rmd
+++ b/r_package/testing/testing_Rpackage.Rmd
@@ -117,7 +117,31 @@ check_bestcost(result_list_bestcost = att_pm_copd_bestcost,
 
 
 ```
+```{r single exposure value and relative risk}
 
+# Assess attributable cases using the AirQ+ export as input data
+att_pm_copd_1rr_bestcost <-
+  bestcost::attribute_health_singlebhd_rr(
+    exp = airqplus_copd$mean_concentration,
+    cutoff = airqplus_copd$cut_off_value,   
+    bhd = airqplus_copd$incidents_per_100_000_per_year/1E5*airqplus_copd$population_at_risk,
+    rr = airqplus_copd$relative_risk,
+    rr_increment = 10, 
+    erf_shape = "log_linear", 
+    info = paste0(airqplus_copd$pollutant,"_", airqplus_copd$evaluation_name))
+
+# Store the central, lower and upper estimate of the AirQ+ assessment
+att_pm_copd_1rr_airqplus_result <- 
+  airqplus_copd %>%
+  dplyr::select(estimated_number_of_attributable_cases_central)%>%
+  unlist()
+
+
+check_bestcost(result_list_bestcost = att_pm_copd_bestcost,
+               result_vector_alternative = att_pm_copd_airqplus_result)
+
+
+```
 
 
 ```{r exposure distribution}
@@ -193,6 +217,9 @@ check_bestcost(result_list_bestcost = att_noise_ha_bestcost,
 ```
 
 
+
+### Life table
+
 ```{r Test probability of dying}
 # Use function
 prob_dying_airqplus <- 
@@ -206,30 +233,10 @@ prob_dying_airqplus <-
   )
 ```
 
-```{r Test attribute_yld_rr single input value, eval=FALSE, include=FALSE}
-yld_test <- bestcost::attribute_yld_rr(
-  dw = 0.133, # for health state "Asthma, uncontrolled" (cf. bestcost::disability_weights)
-  exp = c(input_data_morbidities$exp[12], input_data_morbidities$exp[12]+20, input_data_morbidities$exp[12]+30),
-  prop_pop_exp = c(0.2, 0.2, 0.6),
-  cutoff = input_data_morbidities$cutoff[12],    # PM2.5=5, NO2=10, i.e. WHO AQG 2021 
-  bhd = input_data_morbidities$bhd_absolute[12],
-  rr = unlist(input_data_morbidities[12, c("rr_central", "rr_lower", "rr_upper")]), # RR for asthma incidence for adults
-  rr_increment = 10, 
-  erf_shape = "log_linear", 
-  info_pollutant = input_data_morbidities$pollutant[12], 
-  info_outcome = input_data_morbidities$outcome_metric[12]
-)
 
-
-# Ref 2783  583 4719 
-# Ref * 0.133: 370  78  628
-```
-
-
-### Life table
 ```{r yll lifetable}
-impact_yll_expDistribution_raw <- list()
-impact_yll_expDistribution_raw[[input_data_mortality$year[2]]][[input_data_mortality$rr_id[[2]]]] <-
+impact_yll_expDistribution <- list()
+impact_yll_expDistribution[[input_data_mortality$year[2]]][[input_data_mortality$rr_id[[2]]]] <-
     bestcost::attribute_yll_lifetable_rr(
       exp = input_data_mortality$exp[2],
       # exp = c(8, 9, 10), # Fake data just for testing purposes
@@ -256,6 +263,39 @@ impact_yll_expDistribution_raw[[input_data_mortality$year[2]]][[input_data_morta
 
 head(impact_yll_expDistribution_raw$`2019`$`PM2.5_premature deaths_all causes_adults_main_ERS-ISEE_2022_selected`$total$impact)
 ```
+
+
+```{r yll lifetable with single relative risk}
+impact_yll_expDistribution_1rr <- list()
+impact_yll_expDistribution_1rr[[input_data_mortality$year[2]]][[input_data_mortality$rr_id[[2]]]] <-
+    bestcost::attribute_yll_lifetable_rr(
+      exp = input_data_mortality$exp[2],
+      # exp = c(8, 9, 10), # Fake data just for testing purposes
+      prop_pop_exp = 1,
+      # prop_pop_exp = c(0.2, 0.3, 0.5), # Fake data just for testing purposes
+      cutoff = input_data_mortality$cutoff[2], # WHO AQG 2021 
+      rr = unlist(input_data_mortality[2, c("rr_central")]),
+      rr_increment = 10, 
+      erf_shape = "log_linear",
+      first_age_pop = 0,
+      last_age_pop = 99,
+      interval_age_pop = 1,
+      prob_natural_death_male = lifetable_withPopulation[["male"]]$death_probability_natural,
+      prob_natural_death_female = lifetable_withPopulation[["female"]]$death_probability_natural,
+      prob_total_death_male = lifetable_withPopulation[["male"]]$death_probability_total,
+      prob_total_death_female = lifetable_withPopulation[["female"]]$death_probability_total,
+      population_male = lifetable_withPopulation[["male"]]$population, 
+      population_female = lifetable_withPopulation[["female"]]$population, 
+      year_of_analysis = 2019, 
+      info = input_data_mortality$pollutant[2], 
+      min_age = if(is.na(input_data_mortality$min_age[2])) NULL else input_data_mortality$min_age[2],
+      max_age = 99)
+      #max_age = if(is.na(input_data_mortality$max_age[2])) NULL else input_data_mortality$max_age[2])
+
+head(impact_yll_expDistribution_raw$`2019`$`PM2.5_premature deaths_all causes_adults_main_ERS-ISEE_2022_selected`$total$impact)
+```
+
+
 
 
 ```{r mortality using exposure distribution}
@@ -474,7 +514,40 @@ yld <- attribute_yld_lifetable_rr(
 print(paste("YLD", head(yld$total$impact_rounded)))
 print("YLL (not discounted, as comparison) 40541.98 14640.90 27741.97")
 ```
+```{r morbidity yld lifetable with single relative risk}
+yld_1rr <- attribute_yld_lifetable_rr(
+  exp = input_data_mortality$exp[2],
+  # exp = c(8, 9, 10), # Fake data just for testing purposes
+  prop_pop_exp = 1,
+  # prop_pop_exp = c(0.2, 0.3, 0.5), # Fake data just for testing purposes
+  cutoff = input_data_mortality$cutoff[2],
+  rr = unlist(input_data_mortality[2, c("rr_central")]), # "rr_central", 
+  rr_increment = 10, 
+  erf_shape = "log_linear",
+  first_age_pop = 0,last_age_pop = 99,
+  interval_age_pop = 1,
+  prob_natural_death_male = lifetable_withPopulation[["male"]]$death_probability_natural,
+  prob_natural_death_female = lifetable_withPopulation[["female"]]$death_probability_natural,
+  prob_total_death_male = lifetable_withPopulation[["male"]]$death_probability_total,
+  prob_total_death_female = lifetable_withPopulation[["female"]]$death_probability_total,
+  population_male = lifetable_withPopulation[["male"]]$population, 
+  population_female = lifetable_withPopulation[["female"]]$population,
+  year_of_analysis = 2019, 
+  info = input_data_mortality$pollutant[2], 
+  # min_age = 20,
+  min_age = input_data_mortality$min_age[2],
+  # min_age = NA,
+  max_age = 99,
+  # max_age = input_data_mortality$max_age[2],
+  # max_age = NA,
+  corrected_discount_rate = 0,
+  # duration = 2,
+  disability_weight = 1
+  )
 
+print(paste("YLD", head(yld$total$impact_rounded)))
+print("YLL (not discounted, as comparison) 40541.98 14640.90 27741.97")
+```
 
 ## Comparison
 


### PR DESCRIPTION
In the former version of the package, only vectors of three elements (central estimate, lower bound and upper bound) were accepted as input data for the relative risk in attribute_ functions. Now single-value relative risks are also accepted.
Main changes:

- In the loop of `get_yll()`, `get_yld()` and `get_death()` instead of using string vectors (e.g. `c("central", "lower", "upper")`), a more flexible coding referring to existring list element names or column values has been implemented.
- The `ifelse()` of `compile_input()` has been modified to ensure that single-value relative risks get the "central" category in `erf_ci` instead of `lower`. The code ine the `ifelse()` is now a bit longer, but prevents additional if statements that could make the performance slower.