### PR TITLE
Consistent (not duplicated) rounding of impacts

### DIFF
--- a/r_package/bestcost/R/get_deaths.R
+++ b/r_package/bestcost/R/get_deaths.R
@@ -72,7 +72,7 @@ get_deaths <-
                     across(where(is.character), ~"total"),
                     .groups = "keep")) %>%
       # Round column impact
-      dplyr::mutate(impact_rounded = round(impact, 0)) %>%
+      # dplyr::mutate(impact_rounded = round(impact, 0)) %>%
 
       # Add approach and metric and round
       # dplyr::mutate(impact_metric = "Premature deaths") %>%

--- a/r_package/bestcost/R/get_impact.R
+++ b/r_package/bestcost/R/get_impact.R
@@ -44,12 +44,9 @@ get_impact <-
           dplyr::mutate(impact = pop_fraction * bhd) %>%
           {if(unique(input$health_metric) == "yld_from_prevalence")
             dplyr::mutate(., impact = impact * disability_weight) else .} %>%
-          dplyr::mutate(
-            impact_rounded =
-              round(impact, 0)) %>%
           # Order columns
           dplyr::select(exp_ci, bhd_ci, erf_ci,
-                        pop_fraction, impact, impact_rounded,
+                        pop_fraction, impact,
                         everything())
         impact_raw = list(main = impact_raw_main)
 
@@ -112,12 +109,16 @@ get_impact <-
         input %>%
         dplyr::mutate(
           absolute_risk_as_percent = bestcost::get_risk(exp = exp, erf_c = erf_c, erf_full = TRUE) ,
-          impact = absolute_risk_as_percent/100 * pop_exp,
-          impact_rounded = round(impact, 0))
+          impact = absolute_risk_as_percent/100 * pop_exp)
 
       impact_raw = list(main = impact_raw_main)
 
     }
+
+    # Round impacts
+    impact_raw[["main"]] <-
+      impact_raw[["main"]] %>%
+      dplyr::mutate(impact_rounded = round(impact, 0))
 
 
 

--- a/r_package/bestcost/R/get_output.R
+++ b/r_package/bestcost/R/get_output.R
@@ -35,16 +35,16 @@ get_output <-
         # Remove all impact rounded because
         # we have to round final results
         # not summing rounded results ("too rounded")
-        dplyr::select(-all_of(intersect(paste0("impact_rounded", c("", "_1", "_2")),
+        dplyr::select(., -all_of(intersect(paste0("impact_rounded", c("", "_1", "_2")),
                                         names(.)))) %>%
         # Collapse the exposure categories to have only a vector
-        dplyr::mutate(across(all_of(intersect(c(paste0("exp", c("", "_1", "_2")),
+        dplyr::mutate(., across(all_of(intersect(c(paste0("exp", c("", "_1", "_2")),
                                                 paste0("pop_exp", c("", "_1", "_2")),
                                                 "exposure_dimension"),
                                               names(.))),
                              ~ paste(., collapse = ", ")))%>%
         # Sum columns to summarize
-        dplyr::group_by(
+        dplyr::group_by(.,
           across(all_of(setdiff(names(.),
                                 c("geo_id_raw",
                                   "pop_exp",
@@ -54,12 +54,12 @@ get_output <-
                                   paste0("pop_fraction", c("", "_1", "_2")),
                                   paste0("absolute_risk_as_percent", c("", "_1", "_2")),
                                   paste0("impact", c("", "_1", "_2"))))))) %>%
-        dplyr::summarize(
+        dplyr::summarize(.,
           across(all_of(intersect(c(paste0("absolute_risk_as_percent", c("", "_1", "_2")),
                                     paste0("impact", c("", "_1", "_2"))),
                                   names(.))),
                  ~sum(.x, na.rm = TRUE)),
-          .groups = "drop") %>%
+          .groups = "drop")%>%
         # Round impact
         dplyr::mutate(impact_rounded = round(impact, 0))
 
@@ -75,7 +75,7 @@ get_output <-
       output[["detailed"]][["agg_geo"]]  <-
         output_last %>%
         # Group by higher geo level
-        dplyr::group_by(across(all_of(intersect(c("geo_id_aggregated", "exp_ci",
+        dplyr::group_by(., across(all_of(intersect(c("geo_id_aggregated", "exp_ci",
                                                   "bhd_ci", "erf_ci"),
                                                 names(.)))))%>%
         dplyr::summarise(impact = sum(impact),

--- a/r_package/bestcost/R/get_yld.R
+++ b/r_package/bestcost/R/get_yld.R
@@ -127,10 +127,6 @@ get_yld <-
       dplyr::left_join(.,
                        input_with_risk_and_pop_fraction,
                        by = "erf_ci")%>%
-
-      # Round the results
-      dplyr::mutate(impact_rounded = round(impact, 0))%>%
-
       # Order columns
       dplyr::select(discounted, sex, erf_ci, everything())%>%
       # Order rows

--- a/r_package/bestcost/R/get_yll.R
+++ b/r_package/bestcost/R/get_yll.R
@@ -130,13 +130,9 @@ get_yll <-
       # Add input_with_risk_and_pop_fraction information (with left join)
       dplyr::left_join(.,
                        input_with_risk_and_pop_fraction,
-                       by = "erf_ci")%>%
-
-      # Round the results
-      dplyr::mutate(impact_rounded = round(impact, 0))%>%
-
+                       by = "erf_ci") %>%
       # Order columns
-      dplyr::select(discounted, sex, erf_ci, everything())%>%
+      dplyr::select(discounted, sex, erf_ci, everything()) %>%
       # Order rows
       dplyr::arrange(discounted, sex, erf_ci)
 


### PR DESCRIPTION
Impacts are only rounded at the end of `get_impact()` and, if needed, when aggregating data in `get_output()`.