### PR TITLE
Bug fixed in compile_input()

### DIFF
--- a/r_package/bestcost/R/compile_input.R
+++ b/r_package/bestcost/R/compile_input.R
@@ -274,11 +274,13 @@ compile_input <-
             population = lifetable_with_pop_male$population + lifetable_with_pop_female$population,
             deaths = lifetable_with_pop_male$deaths + lifetable_with_pop_female$deaths)
 
-        lifetable_with_pop_male_female <-
-          dplyr::bind_rows(lifetable_with_pop_male_female, lifetable_with_pop_total)
+        lifetable_with_pop_male_female_total <-
+          dplyr::bind_rows(lifetable_with_pop_male,
+                           lifetable_with_pop_female,
+                           lifetable_with_pop_total)
 
         lifetable_with_pop <-
-          lifetable_with_pop_male_female %>%
+          lifetable_with_pop_male_female_total %>%
           # Nest the lifetable elements
           tidyr::nest(
             lifetable_with_pop_nest =


### PR DESCRIPTION
There was a bug in compile_input() for airqplus method in lifetable. It has been now fixed. Deaths are not anymore NA and yll not anymore 0. 

Furthermore, the filter to only keep central erf was removed and the code works with out errors, so I assume that the code is robust enough to work with uncertainties in erf.