### PR TITLE
Fixed warning by making sure the two comparators have the same length

### DIFF
--- a/r_package/bestcost/R/get_pop_impact.R
+++ b/r_package/bestcost/R/get_pop_impact.R
@@ -124,7 +124,7 @@ get_pop_impact <-
               # Calculate modified hazard rate = modification factor * hazard rate = mod factor * (deaths / mid-year pop)
               dplyr::mutate(
                 hazard_rate_mod =
-                  dplyr::if_else(age_end > min_age,
+                  dplyr::if_else(age_end > c(rep_len(min_age, length.out = length(age_end))), # This makes sure comparators are of same length
                                  modification_factor * hazard_rate,
                                  hazard_rate),
                 .after = deaths) %>%
@@ -133,14 +133,14 @@ get_pop_impact <-
               # ( 2 - modified hazard rate ) / ( 2 + modified hazard rate )
               dplyr::mutate(
                 prob_survival_mod =
-                  dplyr::if_else(age_end > min_age,
+                  dplyr::if_else(age_end > c(rep_len(min_age, length.out = length(age_end))), # This makes sure comparators are of same length
                                  (2 - hazard_rate_mod) / (2 + hazard_rate_mod),
                                  prob_survival),
                 .after = deaths) %>%
 
               dplyr::mutate(
                 prob_survival_until_mid_year_mod =
-                  dplyr::if_else(age_end > min_age,
+                  dplyr::if_else(age_end > c(rep_len(min_age, length.out = length(age_end))), # This makes sure comparators are of same length
                                  1 - ((1 - prob_survival_mod) / 2),
                                  prob_survival_until_mid_year),
                 .after = deaths)

--- a/r_package/testing/testing_Rpackage.Rmd
+++ b/r_package/testing/testing_Rpackage.Rmd
@@ -1004,7 +1004,7 @@ check_bestcost(result_list_bestcost = comparison_yld_singlebhd_rr_pif_geo ,
 
 ### Lifetable
 
-```{r comparison deaths lifetable, warning=FALSE}
+```{r comparison deaths lifetable, warning=TRUE}
 
 # DELTA
 


### PR DESCRIPTION
Interestingly, the warning only shows up the third time within the `compare_..._from_lifetable()` call that get_pop_impact is called, and only in the `approach_comparison = "pif"` case. Function runs much faster now.