### PR TITLE
No interim in results but a more self-explaining sublist

### DIFF
--- a/r_package/bestcost/R/get_daly.R
+++ b/r_package/bestcost/R/get_daly.R
@@ -78,7 +78,7 @@ get_daly <-
     # Create compile main and detailed results
     impact_raw <- list(
       main = impact_daly_main_raw,
-      detailed = impact_yll_yld_raw
+      detailed = list(impact_yll_yld_raw = impact_yll_yld_raw)
     )
 
     return(impact_raw)

--- a/r_package/bestcost/R/get_deaths_yll_yld.R
+++ b/r_package/bestcost/R/get_deaths_yll_yld.R
@@ -253,7 +253,7 @@ get_deaths_yll_yld <-
 
     # Classify results in main and detailed
     output <- list(main = impact_main,
-                   detailed = impact_detailed)
+                   detailed = list(step_by_step_from_lifetable = impact_detailed))
 
     return(output)
 

--- a/r_package/bestcost/R/get_impact.R
+++ b/r_package/bestcost/R/get_impact.R
@@ -45,7 +45,7 @@ get_impact <-
                         pop_fraction, impact,
                         everything())
 
-        impact_raw = list(main = impact_raw_main)
+        impact_raw <- list(main = impact_raw_main)
 
       } else if (unique(input$health_metric) %in% "yld_from_prevalence") {
 
@@ -60,7 +60,7 @@ get_impact <-
                         pop_fraction, impact,
                         everything())
 
-        impact_raw = list(main = impact_raw_main)
+        impact_raw <- list(main = impact_raw_main)
 
         } else if (unique(input$health_metric) %in% c("deaths_from_lifetable",
                                                       "yll_from_lifetable",
@@ -122,7 +122,7 @@ get_impact <-
           absolute_risk_as_percent = bestcost::get_risk(exp = exp, erf_eq = erf_eq) ,
           impact = absolute_risk_as_percent/100 * pop_exp)
 
-      impact_raw = list(main = impact_raw_main)
+      impact_raw <- list(main = impact_raw_main)
 
     }
 

--- a/r_package/bestcost/R/get_output.R
+++ b/r_package/bestcost/R/get_output.R
@@ -21,9 +21,18 @@
 get_output <-
   function(impact_raw){
 
-    output <- list(main = impact_raw[["main"]],
-                   detailed = list(raw = impact_raw[["main"]],
-                                   interim = impact_raw[["detailed"]]))
+    # Store output so far
+    # The main will chage below that we give a first value
+    output <-
+      impact_raw
+
+    output[["detailed"]][["raw"]] <- impact_raw[["main"]]
+
+    # # If lifetable approach --> store interim results of population impact by age
+    # if(!is.null(impact_raw[["detailed"]])){
+    #   output[["detailed"]][["detailed"]][["interim_lifetable"]] <-
+    #     impact_raw_
+    # }
 
     output_last <-
       output[["main"]]


### PR DESCRIPTION
Bug that showed an empty list element in output (interim) has been now fixed. Instead of interim (which is not clear term), the sublist within detailed has a new sublist with more self-explaining name. They shows the step by step interim results to calculate deaths, yld and yll from lifetable and dalys from yld and yll.