### PR TITLE
Named nested tibbles in lifetable approach

### DIFF
--- a/r_package/bestcost/R/get_deaths_yll_yld.R
+++ b/r_package/bestcost/R/get_deaths_yll_yld.R
@@ -239,6 +239,28 @@ get_deaths_yll_yld <-
       dplyr::bind_rows(impact_detailed, impact_detailed_total)
     }
 
+    # Create ID for the rows (will be used below)
+    id_columns <-
+      c("sex",
+        "exposure_name",
+        "geo_id_raw",
+        "erf_ci", "bhd_ci", "exp_ci", "dw_ci")
+
+    id_columns_in_df <-
+      id_columns[id_columns %in% names(impact_detailed)]
+
+    id <-
+      purrr::pmap_chr(impact_detailed[id_columns_in_df],
+                      ~paste(..., sep = "_"))
+
+    # Name rows with the ids for better overview in Environment
+    impact_detailed <-
+      impact_detailed  %>%
+      dplyr::mutate(across(contains("_nest"),
+                           ~set_names(.x,
+                                      id)))
+
+
     # Get the main results starting from a detailed table of results
     impact_main <-
       impact_detailed %>%
@@ -254,6 +276,8 @@ get_deaths_yll_yld <-
     # Classify results in main and detailed
     output <- list(main = impact_main,
                    detailed = list(step_by_step_from_lifetable = impact_detailed))
+
+
 
     return(output)
 

--- a/r_package/bestcost/R/get_output.R
+++ b/r_package/bestcost/R/get_output.R
@@ -28,14 +28,7 @@ get_output <-
 
     output[["detailed"]][["raw"]] <- impact_raw[["main"]]
 
-    # # If lifetable approach --> store interim results of population impact by age
-    # if(!is.null(impact_raw[["detailed"]])){
-    #   output[["detailed"]][["detailed"]][["interim_lifetable"]] <-
-    #     impact_raw_
-    # }
-
-    output_last <-
-      output[["main"]]
+    output_last <- output[["main"]]
 
 
     if(unique(impact_raw[["main"]]$approach_risk) == "absolute_risk") {
@@ -86,10 +79,12 @@ get_output <-
       output[["detailed"]][["agg_geo"]]  <-
         output_last %>%
         # Group by higher geo level
-        dplyr::group_by(., across(all_of(intersect(c("exposure_name",
-                                                     "geo_id_aggregated", "exp_ci",
-                                                     "bhd_ci", "erf_ci","dw_ci"),
-                                                names(.)))))%>%
+        dplyr::group_by(.,
+                        across(all_of(intersect(
+                          c("exposure_name",
+                            "geo_id_aggregated",
+                            "erf_ci", "exp_ci", "bhd_ci", "dw_ci"),
+                          names(.)))))%>%
         {if(!"impact_deprivation_weighted" %in% names(output_last))
           dplyr::summarise(.,
                            impact = sum(impact),


### PR DESCRIPTION
Now the nested tables in lifetable approach have names insted of numbers to refer to them. See issue #299 