### PR TITLE
377 deviation from correct results in ar pathway with user defined erf with cis in attribute call

### DIFF
--- a/r_package/healthiar/R/get_impact.R
+++ b/r_package/healthiar/R/get_impact.R
@@ -137,13 +137,11 @@ get_impact <-
 
       if ( unique(input$health_metric) == "yld" ) {
 
-        impact_raw_main <-
-          impact_raw_main |>
+        impact_raw <-
+          impact_raw |>
           dplyr::mutate(impact = impact * dw * duration)
 
       }
-
-      impact_raw <- list(health_main = impact_raw_main)
 
     }
 

--- a/r_package/healthiar/R/get_impact.R
+++ b/r_package/healthiar/R/get_impact.R
@@ -174,7 +174,7 @@ get_impact <-
         )|>
         dplyr::mutate(exposure_type = input$exposure_type |> dplyr::first())
 
-      # * Multiple geo units####################################################
+      # * Multiple geo units ###################################################
 
     } else if ( ( unique(impact_raw$approach_risk) == "relative_risk" ) &
                 ( unique(impact_raw$exposure_type) == "exposure_distribution" ) &

--- a/r_package/healthiar/R/get_impact.R
+++ b/r_package/healthiar/R/get_impact.R
@@ -124,6 +124,8 @@ get_impact <-
       ( unique(input$health_metric) == "same_input_output" | unique(input$health_metric) == "yld" )
       ) {
 
+      # browser()
+
       # Calculate absolute risk for each exposure category
       impact_raw <-
         input |>
@@ -132,6 +134,8 @@ get_impact <-
           pop_exp = population * prop_pop_exp,
           impact = absolute_risk_as_percent/100 * pop_exp) |>
         dplyr::mutate(impact_rounded = round(impact, 0))
+
+      # browser()
 
       # * YLD ##################################################################
 

--- a/r_package/healthiar/R/get_risk.R
+++ b/r_package/healthiar/R/get_risk.R
@@ -40,7 +40,7 @@ get_risk <-
 
 # browser()
 
-    if(is.null(erf_eq)){
+    if ( is.null(erf_eq) ) {
 
 
       if ( erf_shape == "linear" ) {
@@ -48,6 +48,8 @@ get_risk <-
           function(c){
             1+( (rr-1) * (c-cutoff)/erf_increment )
           }
+        rr_c <- erf(exp)
+        return(rr_c)
       }
 
 
@@ -56,6 +58,8 @@ get_risk <-
           function(c){
             exp(log(rr) *(c-cutoff)/erf_increment)
           }
+        rr_c <- erf(exp)
+        return(rr_c)
       }
 
 
@@ -64,6 +68,8 @@ get_risk <-
           function(c){
             1+( (rr-1) * (log(c)-log(cutoff))/log(erf_increment) )
           }
+        rr_c <- erf(exp)
+        return(rr_c)
       }
 
       if ( erf_shape == "log_log" ) {
@@ -71,6 +77,8 @@ get_risk <-
           function(c){
             exp( log(rr) *(log(c)-log(cutoff))/log(erf_increment) )
           }
+        rr_c <- erf(exp)
+        return(rr_c)
       }
 
     }
@@ -93,8 +101,11 @@ get_risk <-
         mapply(function(eq, val) {
           base::eval(base::parse(text = eq), list(c = val))
         }, erf_eq, c)
+
       }
 
+      rr_c <- erf(c = exp, erf_eq = erf_eq)
+      return(rr_c)
       # erf_alt <- function(c){
       #
       #   base::eval(base::parse(text = erf_eq[3]))
@@ -118,19 +129,11 @@ get_risk <-
        if (exp < 0){
          exp <- 0 # Avoid negative exposures
        }
+       rr_c <- erf(exp)
+       return(rr_c)
      }
 
 
     }
-
-    ## Original call
-    ## rr for the specific concentration
-    # rr_c <-
-    #   erf(exp)
-
-    ## New call
-    rr_c <- erf(c = exp, erf_eq = erf_eq)
-
-    return(rr_c)
 
   }

--- a/r_package/healthiar/R/get_risk.R
+++ b/r_package/healthiar/R/get_risk.R
@@ -38,12 +38,12 @@ get_risk <-
     # the shape of the function (erf_shape) and
     # the relative risk from the literature
 
-
+# browser()
 
     if(is.null(erf_eq)){
 
 
-      if(erf_shape == "linear"){
+      if ( erf_shape == "linear" ) {
         erf <-
           function(c){
             1+( (rr-1) * (c-cutoff)/erf_increment )
@@ -51,7 +51,7 @@ get_risk <-
       }
 
 
-      if(erf_shape == "log_linear"){
+      if ( erf_shape == "log_linear" ) {
         erf <-
           function(c){
             exp(log(rr) *(c-cutoff)/erf_increment)
@@ -59,14 +59,14 @@ get_risk <-
       }
 
 
-      if(erf_shape == "linear_log"){
+      if ( erf_shape == "linear_log" ) {
         erf <-
           function(c){
             1+( (rr-1) * (log(c)-log(cutoff))/log(erf_increment) )
           }
       }
 
-      if(erf_shape == "log_log"){
+      if ( erf_shape == "log_log" ) {
         erf <-
           function(c){
             exp( log(rr) *(log(c)-log(cutoff))/log(erf_increment) )
@@ -79,14 +79,27 @@ get_risk <-
     # A second option is to define the erf using
     # an own defined option
 
-    if(!is.null(erf_eq) & is.character(erf_eq)){
+    if ( !is.null(erf_eq) & is.character(erf_eq) ) {
 
+      ## Original function
+      # erf <- function(c){
+      #   # eval() and parse() convert the string into a function
+      #   base::eval(base::parse(text = erf_eq))
+      #
+      # }
 
-      erf <- function(c){
-        # eval() and parse() convert the string into a function
-        eval(parse(text = erf_eq))
-
+      ## New function
+      erf <- function(c, erf_eq) {
+        mapply(function(eq, val) {
+          base::eval(base::parse(text = eq), list(c = val))
+        }, erf_eq, c)
       }
+
+      # erf_alt <- function(c){
+      #
+      #   base::eval(base::parse(text = erf_eq[3]))
+      #
+      # }
 
     }
 
@@ -94,7 +107,7 @@ get_risk <-
     # a set of points (x = exposure, y = relative risk)
     # It will be assumed that
 
-    if(!is.null(erf_eq) & is.function(erf_eq)){
+    if ( !is.null(erf_eq) & is.function(erf_eq) ){
 
 
      erf <- erf_eq
@@ -110,9 +123,13 @@ get_risk <-
 
     }
 
-    # rr for the specific concentration
-    rr_c <-
-      erf(exp)
+    ## Original call
+    ## rr for the specific concentration
+    # rr_c <-
+    #   erf(exp)
+
+    ## New call
+    rr_c <- erf(c = exp, erf_eq = erf_eq)
 
     return(rr_c)
 

--- a/r_package/testing/testing_Rpackage.Rmd
+++ b/r_package/testing/testing_Rpackage.Rmd
@@ -946,8 +946,8 @@ bestcost_noise_ha_ar_with_erf_eq <-
     prop_pop_exp = niph_noise_ha_input$population_exposed_total/sum(niph_noise_ha_input$population_exposed_total),
     population = sum(niph_noise_ha_input$population_exposed_total),
     erf_eq_central = "78.9270-3.1162*c+0.0342*c^2",
-    # erf_eq_lower = "78.9270-3.1162*c+0.034*c^2",
-    # erf_eq_upper = "78.9270-3.1162*c+0.04*c^2",
+    erf_eq_lower = "78.9270-3.1162*c+0.034*c^2",
+    erf_eq_upper = "78.9270-3.1162*c+0.04*c^2",
     info = data.frame(pollutant = "road_noise", outcome = "highly_annoyance"),
     )
 # View(bestcost_noise_ha_ar_with_erf_eq)


### PR DESCRIPTION
See #377

Fixed by correctly linking ERFs and concentration values in `get_risk()`

@ungatoverde also improved performance by returning value as soon as result is available in `get_risk()`
This way not all if statement have to be evaluated every time before a value is returned

Checked that examples in `testing_Rpackage` remain correct