### PR TITLE
377 deviation from correct results in ar pathway with user defined erf with cis in attribute call 1

### DIFF
--- a/r_package/healthiar/R/compile_input.R
+++ b/r_package/healthiar/R/compile_input.R
@@ -111,7 +111,11 @@ compile_input <-
         erf_data <- # 1 x 3 tibble
           dplyr::tibble(
             exposure_name = names(erf_eq_central),
-            erf_eq_central = list(erf_eq_central))}
+            ## Functions can't be saved raw in column -> save as list
+            erf_eq_central = list(erf_eq_central),
+            erf_eq_lower = list(erf_eq_lower),
+            erf_eq_upper = list(erf_eq_upper))
+        }
 
     # If a confidence interval for the erf is provided, add the erf columns
     ## NOTE: commented out on 2024-12-16

--- a/r_package/healthiar/R/get_impact.R
+++ b/r_package/healthiar/R/get_impact.R
@@ -31,6 +31,7 @@ get_impact <-
            population = NULL){
 
     # Relative risk ############################################################
+
     if(unique(input$approach_risk) == "relative_risk"){
       # Get pop_fraction and add to the input data frame
       input_with_risk_and_pop_fraction <-
@@ -129,11 +130,13 @@ get_impact <-
       # Calculate absolute risk for each exposure category
       impact_raw <-
         input |>
+        dplyr::rowwise() |>
         dplyr::mutate(
           absolute_risk_as_percent = healthiar::get_risk(exp = exp, erf_eq = erf_eq),
           pop_exp = population * prop_pop_exp,
-          impact = absolute_risk_as_percent/100 * pop_exp) |>
-        dplyr::mutate(impact_rounded = round(impact, 0))
+          impact = absolute_risk_as_percent/100 * pop_exp,
+          impact_rounded = round(impact, 0)) |>
+          ungroup()
 
       # browser()
 

--- a/r_package/healthiar/R/get_risk.R
+++ b/r_package/healthiar/R/get_risk.R
@@ -88,27 +88,21 @@ get_risk <-
     if ( !is.null(erf_eq) & is.character(erf_eq) ) {
 
       ## Original function
-      # erf <- function(c){
-      #   # eval() and parse() convert the string into a function
-      #   base::eval(base::parse(text = erf_eq))
-      #
-      # }
-
-      ## New function
-      erf <- function(c, erf_eq) {
-        mapply(function(eq, val) {
-          base::eval(base::parse(text = eq), list(c = val))
-        }, erf_eq, c)
-
+      erf <- function(c){
+        # eval() and parse() convert the string into a function
+        base::eval(base::parse(text = erf_eq))
       }
-
-      rr_c <- erf(c = exp, erf_eq = erf_eq)
-      return(rr_c)
-      # erf_alt <- function(c){
-      #
-      #   base::eval(base::parse(text = erf_eq[3]))
-      #
+      rr_c <- erf(exp)
+        return(rr_c)
+      ## Option using mapply (runs correctly without rowwise(), see #377 )
+      # erf <- function(c, erf_eq) {
+      #   mapply(function(eq, val) {
+      #     base::eval(base::parse(text = eq), list(c = val))
+      #   }, erf_eq, c)
       # }
+      # rr_c <- erf(c = exp, erf_eq = erf_eq)
+      # return(rr_c)
+
 
     }
 

--- a/r_package/healthiar/R/get_risk_and_paf.R
+++ b/r_package/healthiar/R/get_risk_and_paf.R
@@ -33,7 +33,8 @@ get_risk_and_paf <-
                              exp = exp,
                              cutoff_central = cutoff_central,
                              erf_increment = erf_increment,
-                             erf_shape = erf_shape))
+                             erf_shape = erf_shape)) |>
+      dplyr::ungroup()
 
     # Calculate population attributable fraction (PAF) ####
     input_risk_paf <-

--- a/r_package/healthiar/R/get_risk_and_pif.R
+++ b/r_package/healthiar/R/get_risk_and_pif.R
@@ -25,6 +25,7 @@ get_risk_and_pif <-
     # Calculate health impact attributable to exposure ####
     input_and_risk <-
       input |>
+      dplyr::rowwise() |>
       dplyr::mutate(
         rr_conc_1 =
           healthiar::get_risk(rr = rr,
@@ -39,7 +40,8 @@ get_risk_and_pif <-
                              cutoff_central = cutoff_central,
                              erf_increment = erf_increment,
                              erf_shape = unique(erf_shape)
-          ))
+          )) |>
+      dplyr::ungroup()
 
     # Calculate population impact fraction (PIF) ####
     input_risk_pif <-

--- a/r_package/healthiar/R/get_risk_and_pop_fraction.R
+++ b/r_package/healthiar/R/get_risk_and_pop_fraction.R
@@ -61,25 +61,29 @@ get_risk_and_pop_fraction <-
     input_with_risk_and_pop_fraction <-
       input |>
       ## Add pop fraction type
-      dplyr::mutate(pop_fraction_type = pop_fraction_type) |>
-      ## For the calculations below rowwise approach is needed
-      ## Specifically when more than one exposure type is considered
-      dplyr::rowwise()
+      dplyr::mutate(pop_fraction_type = pop_fraction_type)
 
       ## If PAF
     if ( {{pop_fraction_type}} == "paf" ) {
+
+      # browser()
+
       input_with_risk_and_pop_fraction <- input_with_risk_and_pop_fraction |>
         ## Obtain the relative risk for the relevant concentration
+        rowwise() |>
         dplyr::mutate(rr_conc =
                         healthiar::get_risk(rr = rr,
                                            exp = exp,
                                            cutoff = cutoff,
                                            erf_increment = erf_increment,
                                            erf_shape = erf_shape,
-                                           erf_eq = erf_eq))
+                                           erf_eq = erf_eq)) |>
+        dplyr::ungroup()
+
       ## If PIF
     } else {
       input_with_risk_and_pop_fraction <- input_with_risk_and_pop_fraction |>
+        dplyr::rowwise() |>
         dplyr::mutate(rr_conc_1 =
                         healthiar::get_risk(rr = rr,
                                            exp = exp_1,
@@ -93,10 +97,9 @@ get_risk_and_pop_fraction <-
                                            cutoff = cutoff,
                                            erf_increment = erf_increment,
                                            erf_shape = erf_shape,
-                                           erf_eq = erf_eq))}
-    ## Deactivate rowwise(.)+
-    input_with_risk_and_pop_fraction <- input_with_risk_and_pop_fraction |>
-      dplyr::ungroup()
+                                           erf_eq = erf_eq)) |>
+        dplyr::ungroup()
+      }
 
     # * Correction for multiexposure  ###############################################
     if ( "approach_multiexposure" %in% names(input) ) {

--- a/r_package/healthiar/R/include_summary_uncertainty.R
+++ b/r_package/healthiar/R/include_summary_uncertainty.R
@@ -1267,11 +1267,14 @@ include_summary_uncertainty <- function(
 
     ## Calculate risk for each noise band
     dat <- dat |>
+      ## NOTE: not using rowwise & ungroup because results not altered but running time much longer
+      # dplyr::rowwise() |>
       dplyr::mutate(
         dplyr::across(.cols = dplyr::starts_with("exp_"),
                       .fns = ~ healthiar::get_risk(exp = .x, erf_eq = results[["health_detailed"]][["raw"]]$erf_eq |> dplyr::first(x = _)) / 100,
                       .names = "risk_{str_remove(.col, 'exp_')}")
-      )
+      ) # |>
+      # dplyr::ungroup()
 
     # * * * erf_eq CI's & multiple geo unit case ###############################
     } else if ( length(grep("lower", results[["health_detailed"]][["raw"]][["erf_ci"]])) > 0 ){
@@ -1281,7 +1284,10 @@ include_summary_uncertainty <- function(
 
       ## Calculate risk estimates for each exposure band
       dat <- dat |>
+        ## NOTE: not using rowwise & ungroup because results not altered but running time much longer
+
         ### Central risk estimates
+        # dplyr::rowwise() |>
         dplyr::mutate(
           dplyr::across(.cols = dplyr::starts_with("exp_"),
                         .fns = ~ healthiar::get_risk(exp = .x, erf_eq = results[["health_detailed"]][["raw"]] |> filter(erf_ci == "central") |> pull(erf_eq) |> first()) / 100,
@@ -1298,7 +1304,8 @@ include_summary_uncertainty <- function(
           dplyr::across(.cols = dplyr::starts_with("exp_"),
                         .fns = ~ healthiar::get_risk(exp = .x, erf_eq = results[["health_detailed"]][["raw"]] |> filter(erf_ci == "upper") |> pull(erf_eq) |> first()) / 100,
                         .names = "ri_upper_{str_remove(.col, 'exp_')}")
-        )
+        ) # |>
+        # dplyr::ungroup()
 
       ## For each noise band for each row fit a normal distribution using the risk_..._... columns and simulate 1 value (for that specific row)
       ## Corresponding ri_central_..., ri_lower_... and ri_upper_... columns are used

--- a/r_package/testing/testing_Rpackage.Rmd
+++ b/r_package/testing/testing_Rpackage.Rmd
@@ -484,7 +484,7 @@ bestcost_pm_stroke_mr_brt <-
         method = "natural"),
     erf_eq_lower = stats::splinefun(
         x = MRBRT_stroke$exposure,
-        y = MRBRT_stroke$mean - 0.01,
+        y = MRBRT_stroke$mean,
         method = "natural"),
     erf_eq_upper = stats::splinefun(
         x = MRBRT_stroke$exposure,
@@ -499,7 +499,9 @@ bestcost_pm_stroke_mr_brt <-
 # check_bestcost(result_list_bestcost = bestcost_pm_stroke_mr_brt,
 #                result_vector_alternative = c(249)) # Results on 17 October 2024 (with cutoff = 0)
 check_bestcost(result_list_bestcost = bestcost_pm_stroke_mr_brt,
-               result_vector_alternative = c(32)) # Results on 17 October 2024 (with cutoff = 5 = airqplus_pm_copd$cut_off_value)
+               # result_vector_alternative = c(32)) # Results on 17 October 2024 (with cutoff = 5 = airqplus_pm_copd$cut_off_value),
+               result_vector_alternative = c(32,32,76)) # Results on 19 December 2024 (with cutoff = 5 = airqplus_pm_copd$cut_off_value) & erf_eq uncertainty
+
 ```
 
 

--- a/r_package/testing/testing_Rpackage.Rmd
+++ b/r_package/testing/testing_Rpackage.Rmd
@@ -471,6 +471,7 @@ pop_data <- readRDS(file = "../testing/input/pop_data.RDS")
 
 bestcost_pm_stroke_mr_brt <-
   healthiar::attribute_health(
+    approach_risk = "relative_risk",
     exp_central = pop_data$Concentration,
     prop_pop_exp = pop_data$Viken,
     cutoff_central = 5,
@@ -480,10 +481,18 @@ bestcost_pm_stroke_mr_brt <-
       stats::splinefun(
         x = MRBRT_stroke$exposure,
         y = MRBRT_stroke$mean,
-        method = "natural"))
+        method = "natural"),
+    erf_eq_lower = stats::splinefun(
+        x = MRBRT_stroke$exposure,
+        y = MRBRT_stroke$mean - 0.01,
+        method = "natural"),
+    erf_eq_upper = stats::splinefun(
+        x = MRBRT_stroke$exposure,
+        y = MRBRT_stroke$mean + 0.01,
+        method = "natural")
+    )
 
 # View(bestcost_pm_stroke_niph)
-# print(bestcost_pm_stroke_niph$main[, c("pop_fraction", "impact_rounded")])
 
 # View(bestcost_pm_stroke_mr_brt)
 


### PR DESCRIPTION
See #377

Decided to correct results using `rowwise()` before the `get_risk` calls and leave the code of `get_risk` untouched