### PR TITLE
390 add option of user entered impact vector to `include_social()`

### DIFF
--- a/r_package/testing/testing_Rpackage.Rmd
+++ b/r_package/testing/testing_Rpackage.Rmd
@@ -587,7 +587,7 @@ bestcost_pm_death_social_decile <-
                             n_quantile = 10,
                             approach = "quantile")
 
-# View(bestcost_pm_death_social_decile)
+View(bestcost_pm_death_social_decile)
 
 # Check that results did not change over time
 check_general(
@@ -617,12 +617,15 @@ bestcost_pm_death <-
 bestcost_pm_death_social_decile_impact_vector <- 
   healthiar::include_social(impact = bestcost_pm_death[["health_main"]]$impact,
                             population = bestcost_pm_death[["health_main"]]$population,
+                            bhd = bestcost_pm_death[["health_main"]]$bhd,
+                            exp = bestcost_pm_death[["health_main"]]$exp,
+                            pop_fraction = bestcost_pm_death[["health_main"]]$pop_fraction,
                             geo_id_raw = social_data$CS01012020,
                             social_indicator = social_data$score,
                             n_quantile = 10,
                             approach = "quantile")
 
-# View(bestcost_pm_death_social_decile_impact_vector)
+View(bestcost_pm_death_social_decile_impact_vector)
 
 # Check that results did not change over time
 check_general(


### PR DESCRIPTION
`include_social()` can now do a full social analysis using a user-entered impact vector, similarly to how `include_cost()` can monetize any impact vector.
Also added option to input a population vector, so that the impact rate can be calculated. 
Added the options to enter exposure , bhd and paf input vectors, so that the any user can also obtain "complete" results from include_social in the use case where the function is called without an attribute_...() result.

See #390 for possible further features of `include_social()`

Added example to `testing_Rpackage.Rmd` & checked that the `include_social()` results using user-entered impact and population vectors are the same as for the case using the `attribute()` output as the starting point of the social analysis.

@ungatoverde When the `population` argument is `NULL,` then the main output of `include_social`, which is `impact_rate`, will consequently be `NA`. We have to decide whether or not we even allow the function call with the `population` argument unspecified, or not. To be discussed. I'll only merge this pull request once this is decided.