### PR TITLE
fix bug in impact_per_100k_inhab. 

### DIFF
--- a/r_package/healthiar/R/get_daly.R
+++ b/r_package/healthiar/R/get_daly.R
@@ -77,7 +77,7 @@ get_daly <-
       impact_raw <-
         impact_raw |>
         dplyr::mutate(
-          impact_per_100k = impact / population)
+          impact_per_100k = (impact / population) * 1E5)
     }
 
     # Use args and impact to produce impact

--- a/r_package/healthiar/R/get_output.R
+++ b/r_package/healthiar/R/get_output.R
@@ -131,7 +131,7 @@ get_output <-
           dplyr::summarise(impact = sum(impact),
                            impact_rounded = round(impact),
                            population = sum(population),
-                           impact_per_100k_inhab = impact/population,
+                           impact_per_100k_inhab = (impact / population) * 1E5,
                            .groups = "drop")
         }
 


### PR DESCRIPTION
Multiplication by 1E5 was missing in two functions (get_daly and get_output for iterations)